### PR TITLE
Add WebRTX and Shadowray Playground

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@
 - [Use.GPU](https://usegpu.live) - Reactive/declarative WebGPU runtime
 - [GEngine](https://github.com/hpugis/GEngine) -A basic rendering engine based on WebGPU -by junwei.gu
 - [Thimbleberry](https://github.com/mighdoll/thimbleberry) - Reusuable WebGPU shaders and support functions
+- [WebRTX](https://github.com/codedhead/webrtx) - WebGPU Ray Tracing Extension
 
 ## Gists
 
@@ -152,6 +153,7 @@ Demos might work only on Chrome. Firefox implementation is not complete.
 - [WebGPU-Lab](https://s-macke.github.io/WebGPU-Lab/) - by [Sebastian Macke](https://github.com/s-macke) - [repository](https://github.com/s-macke/WebGPU-Lab)
 - [WebGPU Live Demo Editor](https://www.wgsl.dev/editor) - by [Hepp Maccoy](https://github.com/hepp) - [repository](https://github.com/hepp/webgpu-examples)
 - [Thimbleberry Image Transform Demo](https://thimbleberry.dev) - by [mighdoll](https://vis.social/@mighdoll) - [repository](https://github.com/mighdoll/thimbleberry/tree/main/image-demo)
+- [Shadowray Playground](https://shadowray.gl) - by [codedhead](https://github.com/codedhead)
 
 ## Videos
 


### PR DESCRIPTION
WebRTX: WebGPU Ray Tracing Extension (https://github.com/codedhead/webrtx)
Shadowray Playground: Website that allows editing and running WebRTX app in realtime (https://shadowray.gl)