### PR TITLE
Add PBR renderer article

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@
 - [Efficently rendering glTF models - A WebGPU Case Study](https://toji.github.io/webgpu-gltf-case-study/) - by [Brandon Jones](https://github.com/toji)
 - [WebGPU - All of the cores, none of the canvas](https://surma.dev/things/webgpu/index.html) - by [Surma](https://github.com/surma)
 - [WebGPU Fundamentals](https://webgpufundamentals.org/) - A set of articles to help learn WebGPU
+- [PBR in WebGPU: implementation details](https://tchayen.com/pbr-in-webgpu-implementation-details) - by [Tomasz Czajecki](https://github.com/tchayen)
 
 ## Tutorials
 


### PR DESCRIPTION
Hi!

I wrote a short article about challenges I faced when implementing a Physically Based Renderer with Image Based Lighting (following the wonderful [LearnOpenGL tutorials](https://learnopengl.com/PBR/Theory)). I haven't so far seen any tutorial or article about PBR in WebGPU and it took me quite a bit of trial and error before I figured out how to translate all concepts that I knew from WebGL.

So I assume it can potentially be a huge time saver for someone like me.