### PR TITLE
Add WebGPU memory model testing site

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@ Demos might work only on Chrome. Firefox implementation is not complete.
 - [Web Stable Diffusion](https://mlc.ai/web-stable-diffusion/#text-to-image-generation-demo) - by [CMU, OctoML, Catalyst et al.](https://github.com/mlc-ai) - [repository](https://github.com/mlc-ai/web-stable-diffusion)
 - [WebLLM](https://mlc.ai/web-llm/) - by [CMU, University of Washington, OctoML, et al.](https://github.com/mlc-ai) - [repository](https://github.com/mlc-ai/web-llm)
 - [Shader Graph WGSL](https://deepkolos.github.io/shader-graph-wgsl/) - by [deepkolos](https://github.com/deepkolos) - [repository](https://github.com/deepkolos/shader-graph-wgsl)
+- [WebGPU Memory Model Testing](https://gpuharbor.ucsc.edu/webgpu-mem-testing/) - by [Reese Levine](https://github.com/reeselevine) et al., UC Santa Cruz - [repository](https://github.com/reeselevine/webgpu-litmus)
 
 ## Videos
 


### PR DESCRIPTION
Hi,

Thought I'd propose adding our WebGPU memory model testing site to the list of demos. The site tests the details of WebGPU's memory model, specifically the semantics of relaxed atomic accesses, and has been an important part of several papers we've published on testing memory models.

Thanks,
Reese