### PR TITLE
Remove link to X/Twitter account

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,6 @@ WebGPU is a work in progress Web standard from [W3C](https://www.w3.org/) for mo
 
 ### Official websites
 - [GPUWeb](https://github.com/gpuweb/gpuweb) - Official GitHub repository.
-- [WebGPU - Twitter](https://x.com/webgpu) - Official X/Twitter account.
 - [Official WebGPU Explainer](https://gpuweb.github.io/gpuweb/explainer/)
 
 ### WebGPU Specifications


### PR DESCRIPTION
It is not official (see https://github.com/gpuweb/gpuweb/discussions/5126)