### PR TITLE
Add Therapy Warsaw Flow-Field to Demos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,8 @@ Right now, demos work best on Chrome/Edge.
 - [Marching Cubes WebGPU](https://conorpo.github.io/marching-cubes-webgpu/) - Marching cubes implementation, by [Conor O'Malley](https://github.com/conorpo) - [Repository](https://github.com/conorpo/marching-cubes-webgpu)
 - [WebGPU Path Tracing](https://iamferm.in/webgpu-path-tracing/) - A path tracer powered by WebGPU compute shaders, by [Fermin Lozano](https://github.com/ferminLR) - [Repository](https://github.com/ferminLR/webgpu-path-tracing)
 - [Real-Time GPU Texture Compression Demo](https://ludicon.com/sparkjs/gltf-demo/) - Showcases the advantages of real-time texture compression. Compares models using KTX2 textures against AVIF + Spark.
+- [Therapy Warsaw Flow-Field](https://therapywarsaw.com) - Dual-stack WebGPU/WebGL2 generative engine visualizing psychotherapy as flowing patterns emerging from complexity. Spring physics, Oklab color mixing, 9 morphing presets. [Source](https://github.com/23x2/generative-flow-field)
+
 
 ## Videos
 


### PR DESCRIPTION
## New Demo: Therapy Warsaw Flow-Field

**URL:** https://therapywarsaw.com
**Source:** https://github.com/23x2/generative-flow-field

A WebGPU/WebGL2 generative visualization built as a visual metaphor for psychotherapy — flowing lines represent complex inner experience settling into coherent patterns.

**Technical highlights:**
- Dual-stack: WebGPU primary, WebGL2 automatic fallback
- OffscreenCanvas + Web Workers
- Transform Feedback physics
- Spring-based animation with Oklab color mixing
- 9 visual presets that morph during page navigation

This is a real production website for a psychotherapy practice in Warsaw, not a demo.