### PR TITLE
Add Kiln — WebGPU-native out-of-core volume rendering system

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,7 @@ WebGPU is a work in progress Web standard from [W3C](https://www.w3.org/) for mo
 - [spark.js](https://ludicon.com/sparkjs/) - A real-time GPU texture compression library for WebGPU.
 - [zephyr3d](https://zephyr3d.org/) - A TypeScript-based 3D rendering engine with WebGPU/WebGL support.
 - [ChartGPU](https://github.com/chartgpu/chartgpu) - High-performance charting library built on WebGPU, handles 1M+ data points at 60fps.
+- [Kiln](https://github.com/MPanknin/kiln-render) - A WebGPU-native out-of-core rendering system for large virtualized volumetric data.
 
 ## Debuggers and Profilers
 - [webgpu-inspector](https://github.com/brendan-duncan/webgpu_inspector) - Inspection debugger for WebGpu.


### PR DESCRIPTION
## Add Kiln — WebGPU-native out-of-core volume rendering system

https://github.com/MPanknin/kiln-render

### What is it?

**Kiln** is an end-to-end system for rendering large volumetric datasets in the browser using WebGPU. It covers the full pipeline: data preprocessing, HTTP streaming, decompression, memory virtualization, and rendering — making multi-gigabyte CT scans and scientific volumes interactive in a standard browser tab.

Key technical highlights:
- **Virtual texturing for volumes** — modest VRAM footprint regardless of dataset size, via a pre-allocated page cache and virtual texture coordinate indirection
- **Out-of-core streaming** — HTTP Range requests, SSE-based LOD selection, LRU brick eviction
- **Compute shader raycasting** — brick-aware raymarching with early termination, DVR / MIP / Isosurface modes
- **Parallel decompression** — gzip brick decompression via Web Workers
- **Preprocessing pipeline** — scripts to convert raw volumes into the Kiln sharded binary format
- **Format support** — Kiln sharded binary and experimental OME-Zarr
- **Live demos** — 2+ GB CT scans running at interactive framerates in the browser

Even though capable WebGL volume rendering solutions exists, the motivation here was to build the system fully around WebGPU from the beginning. More detailed reasoning behind the technology choice [can be found here](https://github.com/MPanknin/kiln-render/blob/main/docs/webgpu.md).

### Why is this a useful contribution to the ecosystem?

WebGPU volume rendering examples do exist, but they all assume fully GPU-resident datasets — the entire volume is uploaded to VRAM upfront, which caps practical dataset sizes at a few hundred megabytes at best. 

Kiln overcomes this limitation: it treats GPU memory as a fixed-size cache and streams only the bricks the current view actually needs, making gigabyte-scale datasets viable in the browser. 

Virtual texturing and out-of-core streaming are well-established in native graphics, but there is almost no prior WebGPU-native implementation of these techniques applied to volumetric data. Kiln fills that gap and documents the design decisions in detail, making it a concrete reference for anyone tackling large-scale scientific visualization on the web.

For anyone working on medical imaging, scientific visualization, or large-scale 3D data in the browser, this represents a concrete, open-source starting point rather than having to piece together the architecture from scratch.

### Suggested category

I'd suggest placing this in the *Libraries / Tools** section since it contains all components needed for rendering end-to-end. 

### A note

This is my own personal project. I've tried to build something that is genuinely useful to the WebGPU community rather than just another demo, and submitting it here is my small way of giving something back to an ecosystem I've learned a lot from. 

Happy to adjust the entry wording or placement based on maintainer feedback.

---

**Checklist**
- [x] The project is directly related to WebGPU
- [x] The repository is public and actively maintained
- [x] A live demo is available
- [x] The project is MIT licensed
- [x] The entry follows the existing formatting style