### PR TITLE
Added Shade - WebGPU graphics engine

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,7 @@ WebGPU is a work in progress Web standard from [W3C](https://www.w3.org/) for mo
 - [spark.js](https://ludicon.com/sparkjs/) - A real-time GPU texture compression library for WebGPU.
 - [zephyr3d](https://zephyr3d.org/) - A TypeScript-based 3D rendering engine with WebGPU/WebGL support.
 - [ChartGPU](https://github.com/chartgpu/chartgpu) - High-performance charting library built on WebGPU, handles 1M+ data points at 60fps.
+- [Shade](https://shade.company-named.com/) - A high-performance WebGPU graphics engine with beutiful visuals.
 
 ## Debuggers and Profilers
 - [webgpu-inspector](https://github.com/brendan-duncan/webgpu_inspector) - Inspection debugger for WebGpu.
@@ -194,6 +195,7 @@ Right now, demos work best on Chrome/Edge.
 - [WebGPU Path Tracing](https://iamferm.in/webgpu-path-tracing/) - A path tracer powered by WebGPU compute shaders, by [Fermin Lozano](https://github.com/ferminLR) - [Repository](https://github.com/ferminLR/webgpu-path-tracing)
 - [WebGPU real-time ray tracer](https://github.com/C-none/Web-RTRT/) - A real-time ray tracer implementing ReSTIR algorithm - [Repository](https://github.com/C-none/Web-RTRT)
 - [Real-Time GPU Texture Compression Demo](https://ludicon.com/sparkjs/gltf-demo/) - Showcases the advantages of real-time texture compression. Compares models using KTX2 textures against AVIF + Spark.
+- [Shade WebGPU examples](https://shade.company-named.com/examples/) - Various demos such as Volumetric Light maps, Clustered lighting and ray tracing.
 
 ## Videos
 


### PR DESCRIPTION
- Added Shade WebGPU graphics engine and examples to the readme.

I'm the author of the engine, would be happy to answer any questions.

Here's more info: https://discourse.threejs.org/t/shade-webgpu-graphics/

<img width="1078" height="1074" alt="Screenshot 2026-04-20 224246 - RCAS" src="https://github.com/user-attachments/assets/d5d60a68-9587-4494-86c1-48f4df22f39b" />
<img width="1078" height="1078" alt="Screenshot 2026-04-21 153210" src="https://github.com/user-attachments/assets/37147481-5883-46bf-8a6a-c3bad9d8f164" />