### PR TITLE
Add Zero — multiplayer voxel sandbox (Three.js TSL + Rust→WASM)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,7 @@ Right now, demos work best on Chrome/Edge.
 - [WebGPU Path Tracing](https://iamferm.in/webgpu-path-tracing/) - A path tracer powered by WebGPU compute shaders, by [Fermin Lozano](https://github.com/ferminLR) - [Repository](https://github.com/ferminLR/webgpu-path-tracing)
 - [WebGPU real-time ray tracer](https://github.com/C-none/Web-RTRT/) - A real-time ray tracer implementing ReSTIR algorithm - [Repository](https://github.com/C-none/Web-RTRT)
 - [Real-Time GPU Texture Compression Demo](https://ludicon.com/sparkjs/gltf-demo/) - Showcases the advantages of real-time texture compression. Compares models using KTX2 textures against AVIF + Spark.
+- [Zero](https://0.space) - Multiplayer voxel sandbox built with Three.js TSL (WebGPU renderer with WebGL fallback). Custom Rust voxel engine compiled to WebAssembly performs the Dual Contouring meshing in a worker pool. Cloudflare Worker + Durable Object for the multiplayer layer.
 
 ## Videos
 


### PR DESCRIPTION
Adds [Zero](https://0.space) to the **Demos** section.

- Multiplayer voxel sandbox running in the browser, free, no install, no signup
- Renderer: Three.js with TSL (WebGPU backend, WebGL fallback for unsupported browsers)
- Meshing: custom voxel engine in Rust → WebAssembly, running in a worker pool, using Dual Contouring
- Multiplayer: Cloudflare Worker + Durable Object
- Same WASM engine also ships native to macOS, Windows, and iOS

Placed after the texture-compression demo at the end of the Demos list. Happy to reposition or trim the description if you'd prefer.