### PR TITLE
Add Darkly.art to WebGPU demo list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@ These have not been updated for a while:
 Right now, demos work best on Chrome/Edge.
 
 - [WebGPU Samples](https://webgpu.github.io/webgpu-samples/) - A set of samples and demos demonstrating the use of the WebGPU API - [Repository](https://github.com/webgpu/webgpu-samples)
+- [Darkly.art](https://demo.darkly.art) - Open-source photo editor with an advanced WebGPU compositor written in Rust + WebAssembly - [Repository](https://github.com/darkly-art/darkly)
 - [WebGPU first-person exploration of the Sponza Palace](https://toji.github.io/webgpu-test/) - Scene render comparison between WebGL, WebGL 2.0 and WebGPU, by Brandon Jones - [Repository](https://github.com/toji/webgpu-test)
 - [WebGPU Clustered Shading](https://toji.github.io/webgpu-clustered-shading/) - By Brandon Jones - [Repository](https://github.com/toji/webgpu-clustered-shading)
 - [WebGPU Metaballs](https://toji.github.io/webgpu-metaballs/) - By Brandon Jones - [Repository](https://github.com/toji/webgpu-metaballs)


### PR DESCRIPTION
Thanks for putting this list together. I added a new entry for [Darkly](https://darkly.art), a WebGPU-powered photo editor. 

https://github.com/user-attachments/assets/e0af23a9-0f42-430d-ad27-ffc26a3b2e9a

Demo: https://demo.darkly.art
Github: https://github.com/darkly-art/darkly