### PR TITLE
Add Mixos to Demos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,7 @@ Right now, demos work best on Chrome/Edge.
 - [WebGPU Path Tracing](https://iamferm.in/webgpu-path-tracing/) - A path tracer powered by WebGPU compute shaders, by [Fermin Lozano](https://github.com/ferminLR) - [Repository](https://github.com/ferminLR/webgpu-path-tracing)
 - [WebGPU real-time ray tracer](https://github.com/C-none/Web-RTRT/) - A real-time ray tracer implementing ReSTIR algorithm - [Repository](https://github.com/C-none/Web-RTRT)
 - [Real-Time GPU Texture Compression Demo](https://ludicon.com/sparkjs/gltf-demo/) - Showcases the advantages of real-time texture compression. Compares models using KTX2 textures against AVIF + Spark.
+- [Mixos](https://www.mixos.io) - A browser-based 3D texture painter — paint, layer and mask PBR materials on any model, bake mesh maps, and export render-ready PBR maps, powered by WebGPU.
 
 ## Videos
 


### PR DESCRIPTION
Adds **Mixos** to the *Demos* list — a browser-based 3D texture painter built on WebGPU: paint, layer and mask PBR materials directly on a model, bake mesh maps, and export render-ready PBR map sets, all in the browser. https://www.mixos.io

It's a real-world WebGPU application (in the spirit of the other apps/tools in this section). Thanks for maintaining the list!