### PR TITLE
Add Difference-of-Gaussians (DoG) Studio demo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,7 @@ Right now, demos work best on Chrome/Edge.
 - [WebGPU Path Tracing](https://iamferm.in/webgpu-path-tracing/) - A path tracer powered by WebGPU compute shaders, by [Fermin Lozano](https://github.com/ferminLR) - [Repository](https://github.com/ferminLR/webgpu-path-tracing)
 - [WebGPU real-time ray tracer](https://github.com/C-none/Web-RTRT/) - A real-time ray tracer implementing ReSTIR algorithm - [Repository](https://github.com/C-none/Web-RTRT)
 - [Real-Time GPU Texture Compression Demo](https://ludicon.com/sparkjs/gltf-demo/) - Showcases the advantages of real-time texture compression. Compares models using KTX2 textures against AVIF + Spark.
+- [DoG Studio](https://dougfenstermacher.com/dogpack/) - Browser-based line art & screentone tool using XDoG/FDoG/ADoG/HDoG algorithms, by [Doug Fenstermacher](https://github.com/dpfens) - [Repository](https://github.com/dpfens/dogpack/tree/gh-pages)
 
 ## Videos
 


### PR DESCRIPTION
Adds parametric sketch-ification app for images and/or videos.

Demo: https://dougfenstermacher.com/dogpack/
Source Code:
- Library: https://github.com/dpfens/dogpack
- App: https://github.com/dpfens/dogpack/tree/gh-pages